### PR TITLE
Macro definition of snprintf conflicts 

### DIFF
--- a/port/port_win.h
+++ b/port/port_win.h
@@ -31,7 +31,9 @@
 #ifndef STORAGE_LEVELDB_PORT_PORT_WIN_H_
 #define STORAGE_LEVELDB_PORT_PORT_WIN_H_
 
-#define snprintf _snprintf
+#if _MSC_VER>=1900
+#  define STDC99
+#endif
 #define close _close
 #define fread_unlocked _fread_nolock
 

--- a/port/port_win.h
+++ b/port/port_win.h
@@ -31,9 +31,14 @@
 #ifndef STORAGE_LEVELDB_PORT_PORT_WIN_H_
 #define STORAGE_LEVELDB_PORT_PORT_WIN_H_
 
-#if _MSC_VER>=1900
+#if _MSC_VER>=1900 //(Visual Studio 2015)
 #  define STDC99
 #endif
+
+#if _MSC_VER<1900 
+#define snprintf _snprintf
+#endif
+
 #define close _close
 #define fread_unlocked _fread_nolock
 


### PR DESCRIPTION
It is true that on all previous versions of Visual Studio, you must use _snprintf() function. But VS 2014 onwards you should not #define it with _snprintf().

Somewhere in your code or most likely in cocos headers, this is done and hence the error.
Check that and remove that #define.
snprintf() is part of C99 specifications.

To enable C99 support : 
```
#if _MSC_VER>=1900
define STDC99
#endif
```